### PR TITLE
feat: Add Transaction links

### DIFF
--- a/src/components/HomePage/AccountCard/AccountTransactions/AccountTransaction/AccountTransaction.tsx
+++ b/src/components/HomePage/AccountCard/AccountTransactions/AccountTransaction/AccountTransaction.tsx
@@ -77,7 +77,7 @@ const AccountTransaction = ({
       (data.status === WithdrawalStatus.PENDING ||
         data.status === WithdrawalStatus.CHECKPOINT)
     ) {
-      onPendingWithdrawal(data.hash)
+      onPendingWithdrawal(data.initializeHash)
     } else if (
       type === TransactionType.PURCHASE &&
       status === TransactionStatus.PENDING

--- a/src/components/Modals/TransactionDetailModal/Data/Data.css
+++ b/src/components/Modals/TransactionDetailModal/Data/Data.css
@@ -1,0 +1,19 @@
+.Data > :first-child {
+  font-size: 13px;
+  line-height: 18px;
+  text-transform: uppercase;
+  color: #736e7d;
+}
+
+.Data > :last-child {
+  font-weight: 600;
+  font-size: 21px;
+  line-height: 30px;
+  letter-spacing: 0.315px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.Data {
+  margin-bottom: 40px;
+}

--- a/src/components/Modals/TransactionDetailModal/Data/Data.tsx
+++ b/src/components/Modals/TransactionDetailModal/Data/Data.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { Props } from './Data.types'
+import './Data.css'
+
+const Data = ({ label, children }: Props) => {
+  return (
+    <div className="Data">
+      <div>{t(`transaction_detail_modal.${label}`)}</div>
+      <div>{children}</div>
+    </div>
+  )
+}
+
+export default React.memo( Data)

--- a/src/components/Modals/TransactionDetailModal/Data/Data.types.ts
+++ b/src/components/Modals/TransactionDetailModal/Data/Data.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  label: string
+  children: React.ReactNode
+}

--- a/src/components/Modals/TransactionDetailModal/Data/index.ts
+++ b/src/components/Modals/TransactionDetailModal/Data/index.ts
@@ -1,0 +1,2 @@
+import Data from './Data'
+export default Data

--- a/src/components/Modals/TransactionDetailModal/ExplorerLink/ExplorerLink.tsx
+++ b/src/components/Modals/TransactionDetailModal/ExplorerLink/ExplorerLink.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
+import { getTransactionHref } from 'decentraland-dapps/dist/modules/transaction/utils'
+import { Props } from './ExplorerLink.types'
+
+const ExplorerLink = ({ network, chainId, txHash }: Props) => {
+  const resolvedChainId = chainId || (network && getChainIdByNetwork(network))
+
+  if (!resolvedChainId) {
+    throw new Error(
+      'At least one of network or chainId must be provided as props'
+    )
+  }
+
+  const href = getTransactionHref({ txHash }, resolvedChainId)
+
+  return (
+    <a href={href} target="_blank" rel="noreferrer">
+      {txHash}
+    </a>
+  )
+}
+
+export default React.memo(ExplorerLink)

--- a/src/components/Modals/TransactionDetailModal/ExplorerLink/ExplorerLink.types.tsx
+++ b/src/components/Modals/TransactionDetailModal/ExplorerLink/ExplorerLink.types.tsx
@@ -1,0 +1,7 @@
+import { ChainId, Network } from '@dcl/schemas'
+
+export type Props = {
+  network?: Network
+  chainId?: ChainId
+  txHash: string
+}

--- a/src/components/Modals/TransactionDetailModal/ExplorerLink/index.ts
+++ b/src/components/Modals/TransactionDetailModal/ExplorerLink/index.ts
@@ -1,0 +1,2 @@
+import ExplorerLink from './ExplorerLink'
+export default ExplorerLink

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.css
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.css
@@ -22,13 +22,6 @@
   margin-bottom: 40px;
 }
 
-.TransactionDetailModal .external-link-icon {
-  position: relative;
-  bottom: .5rem;
-  margin-left: .5rem;
-  color: var(--primary);
-}
-
 .TransactionDetailModal.ui.modal > .header {
   text-align: center;
   border-bottom: 1px solid #ccc;

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.css
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.css
@@ -2,7 +2,7 @@
   font-size: 13px;
   line-height: 18px;
   text-transform: uppercase;
-  color: #736e7d;
+  color: #736E7D;
 }
 
 .TransactionDetailModal.ui.modal .dcl.close {

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.css
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.css
@@ -1,25 +1,5 @@
-.TransactionDetailModal .data > :first-child {
-  font-size: 13px;
-  line-height: 18px;
-  text-transform: uppercase;
-  color: #736E7D;
-}
-
 .TransactionDetailModal.ui.modal .dcl.close {
   margin-top: -5px;
-}
-
-.TransactionDetailModal .data > :last-child {
-  font-weight: 600;
-  font-size: 21px;
-  line-height: 30px;
-  letter-spacing: 0.315px;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.TransactionDetailModal .data {
-  margin-bottom: 40px;
 }
 
 .TransactionDetailModal.ui.modal > .header {

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.css
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.css
@@ -1,23 +1,32 @@
-.TransactionDetailModal .data :first-child {
+.TransactionDetailModal .data > :first-child {
   font-size: 13px;
   line-height: 18px;
   text-transform: uppercase;
-  color: #736E7D;
+  color: #736e7d;
 }
 
 .TransactionDetailModal.ui.modal .dcl.close {
   margin-top: -5px;
 }
 
-.TransactionDetailModal .data :last-child {
+.TransactionDetailModal .data > :last-child {
   font-weight: 600;
   font-size: 21px;
   line-height: 30px;
   letter-spacing: 0.315px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .TransactionDetailModal .data {
   margin-bottom: 40px;
+}
+
+.TransactionDetailModal .external-link-icon {
+  position: relative;
+  bottom: .5rem;
+  margin-left: .5rem;
+  color: var(--primary);
 }
 
 .TransactionDetailModal.ui.modal > .header {
@@ -26,4 +35,3 @@
   margin: 0;
   padding: 20px 32px 28px 32px;
 }
-

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -50,8 +50,9 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
           <div className="data">
             <div>{t('transaction_detail_modal.tx')}</div>
             <a
-              target="_blank"
               href={getTransactionHref({ txHash: data.hash }, data.chainId)}
+              target="_blank"
+              rel="noreferrer"
             >
               {data.hash}
               <Icon

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -66,7 +66,7 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
       className="TransactionDetailModal"
       closeIcon={<Close onClick={onClose} />}
     >
-      <Modal.Header>{'title'}</Modal.Header>
+      <Modal.Header>{t('transaction_detail_modal.title')}</Modal.Header>
       <Modal.Content>
         <Data label={'operation'}>{description}</Data>
         <Data label={'datetime'}>{datetime}</Data>

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -110,11 +110,11 @@ const WithdrawalDataComponent = ({ data }: { data: Transaction['data'] }) => {
 
   return (
     <>
-      <Data label={t('transaction_detail_modal.initialize_tx')}>
+      <Data label={'initialize_tx'}>
         <ExplorerLink network={Network.MATIC} txHash={initializeHash} />
       </Data>
       {finalizeHash && (
-        <Data label={t('transaction_detail_modal.finalize_tx')}>
+        <Data label={'finalize_tx'}>
           <ExplorerLink network={Network.ETHEREUM} txHash={finalizeHash} />
         </Data>
       )}

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -13,6 +13,8 @@ import {
 } from '../../../modules/mana/types'
 import { getStatusMessage } from '../../../modules/mana/utils'
 import './TransactionDetailModal.css'
+import { getTransactionHref } from 'decentraland-dapps/dist/modules/transaction/utils'
+import { Icon } from 'decentraland-ui'
 
 const TransactionDetailModal: React.FC<ModalProps> = ({
   name,
@@ -40,10 +42,26 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
     case TransactionType.TRANSFER:
       data = transaction.data as Transfer
       dataComponent = (
-        <div className="data">
-          <div> {t('transaction_detail_modal.to')} </div>
-          <div> {data.to} </div>
-        </div>
+        <>
+          <div className="data">
+            <div>{t('transaction_detail_modal.to')}</div>
+            <div>{data.to}</div>
+          </div>
+          <div className="data">
+            <div>{t('transaction_detail_modal.tx')}</div>
+            <a
+              target="_blank"
+              href={getTransactionHref({ txHash: data.hash }, data.chainId)}
+            >
+              {data.hash}
+              <Icon
+                className="external-link-icon"
+                size="tiny"
+                name="external"
+              />
+            </a>
+          </div>
+        </>
       )
       break
   }
@@ -61,21 +79,21 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
       <Modal.Header>{t('transaction_detail_modal.title')}</Modal.Header>
       <Modal.Content>
         <div className="data">
-          <div> {t('transaction_detail_modal.operation')} </div>
-          <div> {description} </div>
+          <div>{t('transaction_detail_modal.operation')}</div>
+          <div>{description}</div>
         </div>
         <div className="data">
-          <div> {t('transaction_detail_modal.datetime')} </div>
-          <div> {datetime} </div>
+          <div>{t('transaction_detail_modal.datetime')}</div>
+          <div>{datetime}</div>
         </div>
         <div className="data">
-          <div> {t('transaction_detail_modal.amount')} </div>
-          <div>{amount.toLocaleString()} </div>
+          <div>{t('transaction_detail_modal.amount')}</div>
+          <div>{amount.toLocaleString()}</div>
         </div>
         {dataComponent}
         <div className="data">
-          <div> {t('transaction_detail_modal.status')} </div>
-          <div> {data ? getStatusMessage(type, status, data.status) : ''}</div>
+          <div>{t('transaction_detail_modal.status')}</div>
+          <div>{data ? getStatusMessage(type, status, data.status) : ''}</div>
         </div>
       </Modal.Content>
     </Modal>

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -108,7 +108,7 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
 
 const WithdrawalDataComponent = ({ data }: { data: Transaction['data'] }) => {
   const withdrawals = useSelector(getWithdrawals)
-  const withdrawal = withdrawals.find((w) => w.initializeHash === data.hash)
+  const withdrawal = withdrawals.find((w) => w.initializeHash === data.initializeHash)
 
   return (
     <>

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -35,6 +35,11 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
   switch (transaction.type) {
     case TransactionType.DEPOSIT:
       data = transaction.data as Deposit
+      dataComponent = (
+        <Data label={'initialize_tx'}>
+          <ExplorerLink network={Network.ETHEREUM} txHash={data.hash} />
+        </Data>
+      )
       break
     case TransactionType.WITHDRAWAL:
       data = transaction.data as Withdrawal

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -3,10 +3,7 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Close } from 'decentraland-ui'
 import { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/ModalProvider.types'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
-import { getTransactionHref } from 'decentraland-dapps/dist/modules/transaction/utils'
-import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
-import { ChainId, Network } from '@dcl/schemas'
-import { useSelector } from 'react-redux'
+import { Network } from '@dcl/schemas'
 import {
   Deposit,
   Purchase,
@@ -16,7 +13,9 @@ import {
   Withdrawal,
 } from '../../../modules/mana/types'
 import { getStatusMessage } from '../../../modules/mana/utils'
-import { getWithdrawals } from '../../../modules/mana/selectors'
+import Data from './Data'
+import ExplorerLink from './ExplorerLink'
+import WithdrawalDataComponent from './WithdrawalDataComponent'
 import './TransactionDetailModal.css'
 
 const TransactionDetailModal: React.FC<ModalProps> = ({
@@ -82,72 +81,6 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
         </Data>
       </Modal.Content>
     </Modal>
-  )
-}
-
-type DataProps = {
-  label: string
-  children: React.ReactNode
-}
-
-const Data = ({ label, children }: DataProps) => {
-  return (
-    <div className="data">
-      <div>{t(`transaction_detail_modal.${label}`)}</div>
-      <div>{children}</div>
-    </div>
-  )
-}
-
-const WithdrawalDataComponent = ({ data }: { data: Transaction['data'] }) => {
-  const withdrawals = useSelector(getWithdrawals)
-
-  const withdrawal = React.useMemo(
-    () => withdrawals.find((w) => w.initializeHash === data.initializeHash),
-    [data, withdrawals]
-  )
-
-  if (!withdrawal) {
-    return null
-  }
-
-  const { initializeHash, finalizeHash } = withdrawal
-
-  return (
-    <>
-      <Data label={'initialize_tx'}>
-        <ExplorerLink network={Network.MATIC} txHash={initializeHash} />
-      </Data>
-      {finalizeHash && (
-        <Data label={'finalize_tx'}>
-          <ExplorerLink network={Network.ETHEREUM} txHash={finalizeHash} />
-        </Data>
-      )}
-    </>
-  )
-}
-
-type ExplorerLinkProps = {
-  network?: Network
-  chainId?: ChainId
-  txHash: string
-}
-
-const ExplorerLink = ({ network, chainId, txHash }: ExplorerLinkProps) => {
-  const resolvedChainId = chainId || (network && getChainIdByNetwork(network))
-
-  if (!resolvedChainId) {
-    throw new Error(
-      'At least one of network or chainId must be provided as props'
-    )
-  }
-
-  const href = getTransactionHref({ txHash }, resolvedChainId)
-
-  return (
-    <a href={href} target="_blank" rel="noreferrer">
-      {txHash}
-    </a>
   )
 }
 

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -3,6 +3,10 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Close } from 'decentraland-ui'
 import { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/ModalProvider.types'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
+import { getTransactionHref } from 'decentraland-dapps/dist/modules/transaction/utils'
+import { Icon } from 'decentraland-ui'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
+import { Network } from '@dcl/schemas'
 import {
   Deposit,
   Purchase,
@@ -13,8 +17,8 @@ import {
 } from '../../../modules/mana/types'
 import { getStatusMessage } from '../../../modules/mana/utils'
 import './TransactionDetailModal.css'
-import { getTransactionHref } from 'decentraland-dapps/dist/modules/transaction/utils'
-import { Icon } from 'decentraland-ui'
+import { useSelector } from 'react-redux'
+import { getWithdrawals } from '../../../modules/mana/selectors'
 
 const TransactionDetailModal: React.FC<ModalProps> = ({
   name,
@@ -35,6 +39,7 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
       break
     case TransactionType.WITHDRAWAL:
       data = transaction.data as Withdrawal
+      dataComponent = <WithdrawalDataComponent data={transaction.data} />
       break
     case TransactionType.PURCHASE:
       data = transaction.data as Purchase
@@ -98,6 +103,48 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
         </div>
       </Modal.Content>
     </Modal>
+  )
+}
+
+const WithdrawalDataComponent = ({ data }: { data: Transaction['data'] }) => {
+  const withdrawals = useSelector(getWithdrawals)
+  const withdrawal = withdrawals.find((w) => w.hash === data.hash)
+
+  return (
+    <>
+      {withdrawal?.hash && (
+        <div className="data">
+          <div>{t('transaction_detail_modal.matic_tx')}</div>
+          <a
+            href={getTransactionHref(
+              { txHash: withdrawal.hash },
+              getChainIdByNetwork(Network.MATIC)
+            )}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {withdrawal.hash}
+            <Icon className="external-link-icon" size="tiny" name="external" />
+          </a>
+        </div>
+      )}
+      {withdrawal?.finalizeHash && (
+        <div className="data">
+          <div>{t('transaction_detail_modal.eth_tx')}</div>
+          <a
+            href={getTransactionHref(
+              { txHash: withdrawal.finalizeHash },
+              getChainIdByNetwork(Network.ETHEREUM)
+            )}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {withdrawal.finalizeHash}
+            <Icon className="external-link-icon" size="tiny" name="external" />
+          </a>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -36,7 +36,7 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
     case TransactionType.DEPOSIT:
       data = transaction.data as Deposit
       dataComponent = (
-        <Data label={'initialize_tx'}>
+        <Data label={'tx'}>
           <ExplorerLink network={Network.ETHEREUM} txHash={data.hash} />
         </Data>
       )

--- a/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
+++ b/src/components/Modals/TransactionDetailModal/TransactionDetailModal.tsx
@@ -108,22 +108,22 @@ const TransactionDetailModal: React.FC<ModalProps> = ({
 
 const WithdrawalDataComponent = ({ data }: { data: Transaction['data'] }) => {
   const withdrawals = useSelector(getWithdrawals)
-  const withdrawal = withdrawals.find((w) => w.hash === data.hash)
+  const withdrawal = withdrawals.find((w) => w.initializeHash === data.hash)
 
   return (
     <>
-      {withdrawal?.hash && (
+      {withdrawal?.initializeHash && (
         <div className="data">
           <div>{t('transaction_detail_modal.matic_tx')}</div>
           <a
             href={getTransactionHref(
-              { txHash: withdrawal.hash },
+              { txHash: withdrawal.initializeHash },
               getChainIdByNetwork(Network.MATIC)
             )}
             target="_blank"
             rel="noreferrer"
           >
-            {withdrawal.hash}
+            {withdrawal.initializeHash}
             <Icon className="external-link-icon" size="tiny" name="external" />
           </a>
         </div>

--- a/src/components/Modals/TransactionDetailModal/WithdrawalDataComponent/WithdrawalDataComponent.container.ts
+++ b/src/components/Modals/TransactionDetailModal/WithdrawalDataComponent/WithdrawalDataComponent.container.ts
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux'
+import { getWithdrawals } from '../../../../modules/mana/selectors'
+import { RootState } from '../../../../modules/reducer'
+import WithdrawalDataComponent from './WithdrawalDataComponent'
+import { MapStateProps } from './WithdrawalDataComponent.types'
+
+const mapState = (state: RootState): MapStateProps => ({
+  withdrawals: getWithdrawals(state),
+})
+
+export default connect(mapState)(WithdrawalDataComponent)

--- a/src/components/Modals/TransactionDetailModal/WithdrawalDataComponent/WithdrawalDataComponent.tsx
+++ b/src/components/Modals/TransactionDetailModal/WithdrawalDataComponent/WithdrawalDataComponent.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Network } from '@dcl/schemas'
+import Data from '../Data'
+import { Props } from './WithdrawalDataComponent.types'
+import ExplorerLink from '../ExplorerLink'
+
+const WithdrawalDataComponent = ({ withdrawals, data }: Props) => {
+  const withdrawal = withdrawals.find(
+    (w) => w.initializeHash === data.initializeHash
+  )
+
+  if (!withdrawal) {
+    return null
+  }
+
+  const { initializeHash, finalizeHash } = withdrawal
+
+  return (
+    <>
+      <Data label={'initialize_tx'}>
+        <ExplorerLink network={Network.MATIC} txHash={initializeHash} />
+      </Data>
+      {finalizeHash && (
+        <Data label={'finalize_tx'}>
+          <ExplorerLink network={Network.ETHEREUM} txHash={finalizeHash} />
+        </Data>
+      )}
+    </>
+  )
+}
+
+export default React.memo(WithdrawalDataComponent)

--- a/src/components/Modals/TransactionDetailModal/WithdrawalDataComponent/WithdrawalDataComponent.types.ts
+++ b/src/components/Modals/TransactionDetailModal/WithdrawalDataComponent/WithdrawalDataComponent.types.ts
@@ -1,0 +1,8 @@
+import { Transaction, Withdrawal } from '../../../../modules/mana/types'
+
+export type Props = {
+  withdrawals: Withdrawal[]
+  data: Transaction['data']
+}
+
+export type MapStateProps = Pick<Props, 'withdrawals'>

--- a/src/components/Modals/TransactionDetailModal/WithdrawalDataComponent/index.ts
+++ b/src/components/Modals/TransactionDetailModal/WithdrawalDataComponent/index.ts
@@ -1,0 +1,2 @@
+import WithdrawalDataComponent from './WithdrawalDataComponent.container'
+export default WithdrawalDataComponent

--- a/src/components/Modals/WithdrawalStatusModal/CompleteWithdrawal/CompleteWithdrawal.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/CompleteWithdrawal/CompleteWithdrawal.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
+import { getTransactionHref } from 'decentraland-dapps/dist/modules/transaction/utils'
+import { Network } from '@dcl/schemas'
+import { Radio } from 'decentraland-ui'
+import LinkWrapper from '../LinkWrapper'
+import { WithdrawalStatus } from '../../../../modules/mana/types'
+import { Props } from './CompleteWithdrawal.types'
+
+const CompleteWithdrawal = ({ withdrawal }: Props) => {
+  const { status, finalizeHash } = withdrawal
+
+  const href =
+    finalizeHash &&
+    getTransactionHref(
+      { txHash: finalizeHash },
+      getChainIdByNetwork(Network.ETHEREUM)
+    )
+
+  const radio = (
+    <Radio
+      className={!href ? 'default_cursor' : undefined}
+      checked={status === WithdrawalStatus.COMPLETE}
+      label={t('withdrawal_status_modal.status_completed')}
+    />
+  )
+
+  return href ? <LinkWrapper href={href}>{radio}</LinkWrapper> : radio
+}
+
+export default React.memo(CompleteWithdrawal)

--- a/src/components/Modals/WithdrawalStatusModal/CompleteWithdrawal/CompleteWithdrawal.types.ts
+++ b/src/components/Modals/WithdrawalStatusModal/CompleteWithdrawal/CompleteWithdrawal.types.ts
@@ -1,0 +1,5 @@
+import { Withdrawal } from "../../../../modules/mana/types";
+
+export type Props = {
+  withdrawal: Withdrawal
+}

--- a/src/components/Modals/WithdrawalStatusModal/CompleteWithdrawal/index.ts
+++ b/src/components/Modals/WithdrawalStatusModal/CompleteWithdrawal/index.ts
@@ -1,0 +1,2 @@
+import CompleteWithdrawal from './CompleteWithdrawal'
+export default CompleteWithdrawal

--- a/src/components/Modals/WithdrawalStatusModal/LinkWrapper/LinkWrapper.css
+++ b/src/components/Modals/WithdrawalStatusModal/LinkWrapper/LinkWrapper.css
@@ -1,0 +1,12 @@
+/* Overwrites some <a> styles that are affecting the component */
+.LinkWrapper {
+  font-weight: unset;
+  color: unset;
+}
+
+.LinkWrapper > i {
+  position: relative;
+  bottom: 2px;
+  margin-left: 0.5rem;
+  color: var(--primary);
+}

--- a/src/components/Modals/WithdrawalStatusModal/LinkWrapper/LinkWrapper.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/LinkWrapper/LinkWrapper.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Icon } from 'decentraland-ui'
+import { Props } from './LinkWrapper.types'
+import './LinkWrapper.css'
+
+const LinkWrapper = ({ href, children }: Props) => {
+  return (
+    <a className="LinkWrapper" href={href} target="_blank" rel="noreferrer">
+      {children}
+      <Icon name="external" size="small" />
+    </a>
+  )
+}
+
+export default React.memo(LinkWrapper)

--- a/src/components/Modals/WithdrawalStatusModal/LinkWrapper/LinkWrapper.types.ts
+++ b/src/components/Modals/WithdrawalStatusModal/LinkWrapper/LinkWrapper.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  href: string
+  children: React.ReactNode
+}

--- a/src/components/Modals/WithdrawalStatusModal/LinkWrapper/index.ts
+++ b/src/components/Modals/WithdrawalStatusModal/LinkWrapper/index.ts
@@ -1,0 +1,2 @@
+import LinkWrapper from './LinkWrapper'
+export default LinkWrapper

--- a/src/components/Modals/WithdrawalStatusModal/ReadyToWithdraw/ReadyToWithdraw.css
+++ b/src/components/Modals/WithdrawalStatusModal/ReadyToWithdraw/ReadyToWithdraw.css
@@ -1,0 +1,16 @@
+.ReadyToWithdraw .status_checkpoint_placeholder {
+  font-size: 15px;
+  line-height: 18px;
+  color: #736e7d;
+  margin-left: 34px;
+  margin-top: -5px;
+  margin-bottom: 10px;
+}
+
+.ReadyToWithdraw .ui.radio.checkbox.yellow_check.checked input.hidden + label::before,
+.ReadyToWithdraw .ui.radio.checkbox.yellow_check.checked input.hidden:focus + label::before,
+.ReadyToWithdraw .ui.radio.checkbox.yellow_check.checked input.hidden + label::after,
+.ReadyToWithdraw .ui.radio.checkbox.yellow_check.checked input.hidden:focus + label::after {
+  background-color: var(--danger);
+  border: 2px solid var(--danger);
+}

--- a/src/components/Modals/WithdrawalStatusModal/ReadyToWithdraw/ReadyToWithdraw.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/ReadyToWithdraw/ReadyToWithdraw.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { Radio } from 'decentraland-ui'
+import { Props } from './ReadyToWithdraw.types'
+import { WithdrawalStatus } from '../../../../modules/mana/types'
+import './ReadyToWithdraw.css'
+
+const ReadyToWithdraw = ({ withdrawal }: Props) => {
+  const { status } = withdrawal
+
+  const statusClassName =
+    status === WithdrawalStatus.CHECKPOINT ||
+    status === WithdrawalStatus.COMPLETE
+      ? ''
+      : 'yellow_check'
+
+  return (
+    <div className="ReadyToWithdraw">
+      <Radio
+        checked={true}
+        className={`${statusClassName} default_cursor`}
+        label={t('withdrawal_status_modal.status_checkpoint')}
+      />
+      <div className="status_checkpoint_placeholder">
+        {t('withdrawal_status_modal.status_checkpoint_placeholder')}
+      </div>
+    </div>
+  )
+}
+
+export default React.memo(ReadyToWithdraw)

--- a/src/components/Modals/WithdrawalStatusModal/ReadyToWithdraw/ReadyToWithdraw.types.ts
+++ b/src/components/Modals/WithdrawalStatusModal/ReadyToWithdraw/ReadyToWithdraw.types.ts
@@ -1,0 +1,5 @@
+import { Withdrawal } from "../../../../modules/mana/types";
+
+export type Props = {
+  withdrawal: Withdrawal
+}

--- a/src/components/Modals/WithdrawalStatusModal/ReadyToWithdraw/index.ts
+++ b/src/components/Modals/WithdrawalStatusModal/ReadyToWithdraw/index.ts
@@ -1,0 +1,2 @@
+import ReadyToWithdraw from './ReadyToWithdraw'
+export default ReadyToWithdraw

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawInitialized/WithdrawInitialized.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawInitialized/WithdrawInitialized.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
+import { getTransactionHref } from 'decentraland-dapps/dist/modules/transaction/utils'
+import { Network } from '@dcl/schemas'
+import { Radio } from 'decentraland-ui'
+import { Props } from './WithdrawInitialized.types'
+import LinkWrapper from '../LinkWrapper'
+
+const WithdrawInitialized = ({ withdrawal }: Props) => {
+  const { initializeHash } = withdrawal
+
+  const href = getTransactionHref(
+    { txHash: initializeHash },
+    getChainIdByNetwork(Network.MATIC)
+  )
+
+  return (
+    <LinkWrapper href={href}>
+      <Radio
+        checked={true}
+        label={t('withdrawal_status_modal.status_initialized')}
+      />
+    </LinkWrapper>
+  )
+}
+
+export default React.memo(WithdrawInitialized)

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawInitialized/WithdrawInitialized.types.ts
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawInitialized/WithdrawInitialized.types.ts
@@ -1,0 +1,5 @@
+import { Withdrawal } from "../../../../modules/mana/types";
+
+export type Props = {
+  withdrawal: Withdrawal
+}

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawInitialized/index.ts
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawInitialized/index.ts
@@ -1,0 +1,2 @@
+import WithdrawInitialized from './WithdrawInitialized'
+export default WithdrawInitialized

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.css
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.css
@@ -41,6 +41,12 @@
   padding-bottom: 40px;
 }
 
+/* Overwrites some <a> styles that are affecting the component */
+.WithdrawalStatusModal .scan_link {
+  font-weight: unset;
+  color: unset;
+}
+
 .WithdrawalStatusModal .status {
   display: flex;
   flex-direction: column;

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.css
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.css
@@ -23,15 +23,6 @@
   color: #736E7D;
 }
 
-.WithdrawalStatusModal .status_checkpoint_placeholder {
-  font-size: 15px;
-  line-height: 18px;
-  color: #736E7D;
-  margin-left: 34px;
-  margin-top: -5px;
-  margin-bottom: 10px;
-}
-
 .WithdrawalStatusModal .amount {
   font-weight: 600;
   font-size: 21px;
@@ -39,19 +30,6 @@
   letter-spacing: 0.315px;
   color: #16141A;
   padding-bottom: 40px;
-}
-
-/* Overwrites some <a> styles that are affecting the component */
-.WithdrawalStatusModal .scan_link {
-  font-weight: unset;
-  color: unset;
-}
-
-.WithdrawalStatusModal .scan_link > i {
-  position: relative;
-  bottom: 2px;
-  margin-left: .5rem;
-  color: var(--primary);
 }
 
 .WithdrawalStatusModal .status {
@@ -77,10 +55,6 @@
   padding: 0px 0px 0px 34px
 }
 
-.ui.radio.checkbox.yellow_check.checked input.hidden + label::before, .ui.radio.checkbox.yellow_check.checked input.hidden:focus + label::before, .ui.radio.checkbox.yellow_check.checked input.hidden + label::after, .ui.radio.checkbox.yellow_check.checked input.hidden:focus + label::after {
-    background-color: var(--danger);
-    border: 2px solid var(--danger);
-}
 .WithdrawalStatusModal .ui.button.primary {
   margin-top: 48px;
   width: 100%;

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.css
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.css
@@ -51,6 +51,14 @@
   display: flex;
   flex-direction: column;
 }
+
+.WithdrawalStatusModal .default_cursor.ui.checkbox,
+.WithdrawalStatusModal .default_cursor.ui.checkbox input.hidden + label, 
+.WithdrawalStatusModal .default_cursor.ui.checkbox input.hidden:focus + label, 
+.WithdrawalStatusModal .default_cursor.ui.checkbox input.hidden:active + label {
+  cursor: default;
+}
+
 .ui.checkbox input.hidden + label, 
 .ui.checkbox input.hidden:focus + label, 
 .ui.checkbox input.hidden:active + label {

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.css
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.css
@@ -47,6 +47,13 @@
   color: unset;
 }
 
+.WithdrawalStatusModal .scan_link > i {
+  position: relative;
+  bottom: 2px;
+  margin-left: .5rem;
+  color: var(--primary);
+}
+
 .WithdrawalStatusModal .status {
   display: flex;
   flex-direction: column;

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
@@ -115,16 +115,17 @@ const WithdrawInitialized = ({ withdrawal }: StatusProps) => {
 const ReadyToWithdraw = ({ withdrawal }: StatusProps) => {
   const { status } = withdrawal
 
+  const statusClassName =
+    status === WithdrawalStatus.CHECKPOINT ||
+    status === WithdrawalStatus.COMPLETE
+      ? ''
+      : 'yellow_check'
+
   return (
     <>
       <Radio
         checked={true}
-        className={
-          status === WithdrawalStatus.CHECKPOINT ||
-          status === WithdrawalStatus.COMPLETE
-            ? ''
-            : 'yellow_check'
-        }
+        className={statusClassName + ' ' + 'default_cursor'}
         label={t('withdrawal_status_modal.status_checkpoint')}
       />
       <div className="status_checkpoint_placeholder">
@@ -137,19 +138,20 @@ const ReadyToWithdraw = ({ withdrawal }: StatusProps) => {
 const CompleteWithdrawal = ({ withdrawal }: StatusProps) => {
   const { status, finalizeHash } = withdrawal
 
-  const radio = (
-    <Radio
-      checked={status === WithdrawalStatus.COMPLETE}
-      label={t('withdrawal_status_modal.status_completed')}
-    />
-  )
-
   const href =
     finalizeHash &&
     getTransactionHref(
       { txHash: finalizeHash },
       getChainIdByNetwork(Network.ETHEREUM)
     )
+
+  const radio = (
+    <Radio
+      className={!href ? 'default_cursor' : undefined}
+      checked={status === WithdrawalStatus.COMPLETE}
+      label={t('withdrawal_status_modal.status_completed')}
+    />
+  )
 
   return href ? (
     <a className="scan_link" href={href} target="_blank" rel="noreferrer">

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
@@ -29,7 +29,7 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
     const finalizeTransaction = transactions.find(
       (tx) =>
         tx.actionType === FINISH_WITHDRAWAL_SUCCESS &&
-        tx.payload.withdrawal.hash === metadata.txHash
+        tx.payload.withdrawal.initializeHash === metadata.txHash
     )
     const isTxPending = Boolean(
       finalizeTransaction && isPending(finalizeTransaction.status)

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
@@ -125,7 +125,7 @@ const ReadyToWithdraw = ({ withdrawal }: StatusProps) => {
     <>
       <Radio
         checked={true}
-        className={statusClassName + ' ' + 'default_cursor'}
+        className={`${statusClassName} default_cursor`}
         label={t('withdrawal_status_modal.status_checkpoint')}
       />
       <div className="status_checkpoint_placeholder">

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
@@ -25,7 +25,9 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
       isLoading,
       onFinishWithdrawal,
     } = this.props
-    const withdrawal = withdrawals.find(({ initializeHash }) => metadata.txHash === initializeHash)
+    const withdrawal = withdrawals.find(
+      ({ initializeHash }) => metadata.txHash === initializeHash
+    )
     const finalizeTransaction = transactions.find(
       (tx) =>
         tx.actionType === FINISH_WITHDRAWAL_SUCCESS &&
@@ -74,7 +76,7 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
               {t('withdrawal_status_modal.status_placeholder')}
             </div>
             <a
-              style={{ fontWeight: 'unset', color: 'unset' }}
+              className="scan_link"
               href={initializeHref}
               target="_blank"
               rel="noreferrer"
@@ -99,7 +101,7 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
             </div>
             {finalizeHref ? (
               <a
-                style={{ fontWeight: 'unset' }}
+                className="scan_link"
                 href={finalizeHref}
                 target="_blank"
                 rel="noreferrer"

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Button, Close, Radio } from 'decentraland-ui'
+import { Button, Close, Radio, Icon } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
 import {
@@ -103,12 +103,12 @@ const WithdrawInitialized = ({ withdrawal }: StatusProps) => {
   )
 
   return (
-    <a className="scan_link" href={href} target="_blank" rel="noreferrer">
+    <LinkWrapper href={href}>
       <Radio
         checked={true}
         label={t('withdrawal_status_modal.status_initialized')}
       />
-    </a>
+    </LinkWrapper>
   )
 }
 
@@ -153,11 +153,19 @@ const CompleteWithdrawal = ({ withdrawal }: StatusProps) => {
     />
   )
 
-  return href ? (
+  return href ? <LinkWrapper href={href}>{radio}</LinkWrapper> : radio
+}
+
+type LinkWrapperProps = {
+  href: string
+  children: React.ReactNode
+}
+
+const LinkWrapper = ({ href, children }: LinkWrapperProps) => {
+  return (
     <a className="scan_link" href={href} target="_blank" rel="noreferrer">
-      {radio}
+      {children}
+      <Icon name="external" size="small" />
     </a>
-  ) : (
-    radio
   )
 }

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react'
-import { Button, Close, Radio, Icon } from 'decentraland-ui'
+import { Button, Close } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
-import {
-  getTransactionHref,
-  isPending,
-} from 'decentraland-dapps/dist/modules/transaction/utils'
+import { isPending } from 'decentraland-dapps/dist/modules/transaction/utils'
 import { ChainButton } from 'decentraland-dapps/dist/containers'
 import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { Network } from '@dcl/schemas'
-import { Withdrawal, WithdrawalStatus } from '../../../modules/mana/types'
+import { WithdrawalStatus } from '../../../modules/mana/types'
 import { FINISH_WITHDRAWAL_SUCCESS } from '../../../modules/mana/actions'
 import { Props } from './WithdrawalStatusModal.types'
+import WithdrawInitialized from './WithdrawInitialized'
+import ReadyToWithdraw from './ReadyToWithdraw'
+import CompleteWithdrawal from './CompleteWithdrawal'
 import './WithdrawalStatusModal.css'
 
 export default class WithdrawalStatusModal extends React.PureComponent<Props> {
@@ -88,84 +88,4 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
       </Modal>
     )
   }
-}
-
-type StatusProps = {
-  withdrawal: Withdrawal
-}
-
-const WithdrawInitialized = ({ withdrawal }: StatusProps) => {
-  const { initializeHash } = withdrawal
-
-  const href = getTransactionHref(
-    { txHash: initializeHash },
-    getChainIdByNetwork(Network.MATIC)
-  )
-
-  return (
-    <LinkWrapper href={href}>
-      <Radio
-        checked={true}
-        label={t('withdrawal_status_modal.status_initialized')}
-      />
-    </LinkWrapper>
-  )
-}
-
-const ReadyToWithdraw = ({ withdrawal }: StatusProps) => {
-  const { status } = withdrawal
-
-  const statusClassName =
-    status === WithdrawalStatus.CHECKPOINT ||
-    status === WithdrawalStatus.COMPLETE
-      ? ''
-      : 'yellow_check'
-
-  return (
-    <>
-      <Radio
-        checked={true}
-        className={`${statusClassName} default_cursor`}
-        label={t('withdrawal_status_modal.status_checkpoint')}
-      />
-      <div className="status_checkpoint_placeholder">
-        {t('withdrawal_status_modal.status_checkpoint_placeholder')}
-      </div>
-    </>
-  )
-}
-
-const CompleteWithdrawal = ({ withdrawal }: StatusProps) => {
-  const { status, finalizeHash } = withdrawal
-
-  const href =
-    finalizeHash &&
-    getTransactionHref(
-      { txHash: finalizeHash },
-      getChainIdByNetwork(Network.ETHEREUM)
-    )
-
-  const radio = (
-    <Radio
-      className={!href ? 'default_cursor' : undefined}
-      checked={status === WithdrawalStatus.COMPLETE}
-      label={t('withdrawal_status_modal.status_completed')}
-    />
-  )
-
-  return href ? <LinkWrapper href={href}>{radio}</LinkWrapper> : radio
-}
-
-type LinkWrapperProps = {
-  href: string
-  children: React.ReactNode
-}
-
-const LinkWrapper = ({ href, children }: LinkWrapperProps) => {
-  return (
-    <a className="scan_link" href={href} target="_blank" rel="noreferrer">
-      {children}
-      <Icon name="external" size="small" />
-    </a>
-  )
 }

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
@@ -2,7 +2,10 @@ import * as React from 'react'
 import { Button, Close, Radio } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
-import { isPending } from 'decentraland-dapps/dist/modules/transaction/utils'
+import {
+  getTransactionHref,
+  isPending,
+} from 'decentraland-dapps/dist/modules/transaction/utils'
 import { ChainButton } from 'decentraland-dapps/dist/containers'
 import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { Network } from '@dcl/schemas'
@@ -23,18 +26,34 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
       onFinishWithdrawal,
     } = this.props
     const withdrawal = withdrawals.find(({ hash }) => metadata.txHash === hash)
-    const isTxPending = transactions.some(
+    const finalizeTransaction = transactions.find(
       (tx) =>
         tx.actionType === FINISH_WITHDRAWAL_SUCCESS &&
-        tx.payload.withdrawal.hash === metadata.hash &&
-        isPending(tx.status)
+        tx.payload.withdrawal.hash === metadata.txHash
     )
+    const isTxPending = Boolean(
+      finalizeTransaction && isPending(finalizeTransaction.status)
+    )
+
     if (!withdrawal) {
       return
     }
+
     const { status, amount } = withdrawal
 
     const handleFinishWithdrawal = () => onFinishWithdrawal(withdrawal)
+
+    const initializeHref = getTransactionHref(
+      { txHash: withdrawal.hash },
+      getChainIdByNetwork(Network.MATIC)
+    )
+
+    const finalizeHref =
+      withdrawal.finalizeHash &&
+      getTransactionHref(
+        { txHash: withdrawal.finalizeHash },
+        getChainIdByNetwork(Network.ETHEREUM)
+      )
 
     return (
       <Modal
@@ -54,15 +73,22 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
             <div className="status_placeholder">
               {t('withdrawal_status_modal.status_placeholder')}
             </div>
-            <Radio
-              checked={true}
-              label={t('withdrawal_status_modal.status_initialized')}
-            />
+            <a
+              style={{ fontWeight: 'unset', color: 'unset' }}
+              href={initializeHref}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Radio
+                checked={true}
+                label={t('withdrawal_status_modal.status_initialized')}
+              />
+            </a>
             <Radio
               checked={true}
               className={
                 status === WithdrawalStatus.CHECKPOINT ||
-                  status === WithdrawalStatus.COMPLETE
+                status === WithdrawalStatus.COMPLETE
                   ? ''
                   : 'yellow_check'
               }
@@ -71,10 +97,24 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
             <div className="status_checkpoint_placeholder">
               {t('withdrawal_status_modal.status_checkpoint_placeholder')}
             </div>
-            <Radio
-              checked={status === WithdrawalStatus.COMPLETE}
-              label={t('withdrawal_status_modal.status_completed')}
-            />
+            {finalizeHref ? (
+              <a
+                style={{ fontWeight: 'unset' }}
+                href={finalizeHref}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <Radio
+                  checked={status === WithdrawalStatus.COMPLETE}
+                  label={t('withdrawal_status_modal.status_completed')}
+                />
+              </a>
+            ) : (
+              <Radio
+                checked={status === WithdrawalStatus.COMPLETE}
+                label={t('withdrawal_status_modal.status_completed')}
+              />
+            )}
           </div>
           {status === WithdrawalStatus.COMPLETE && !isTxPending ? (
             <Button primary onClick={onClose}>

--- a/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
+++ b/src/components/Modals/WithdrawalStatusModal/WithdrawalStatusModal.tsx
@@ -25,7 +25,7 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
       isLoading,
       onFinishWithdrawal,
     } = this.props
-    const withdrawal = withdrawals.find(({ hash }) => metadata.txHash === hash)
+    const withdrawal = withdrawals.find(({ initializeHash }) => metadata.txHash === initializeHash)
     const finalizeTransaction = transactions.find(
       (tx) =>
         tx.actionType === FINISH_WITHDRAWAL_SUCCESS &&
@@ -44,7 +44,7 @@ export default class WithdrawalStatusModal extends React.PureComponent<Props> {
     const handleFinishWithdrawal = () => onFinishWithdrawal(withdrawal)
 
     const initializeHref = getTransactionHref(
-      { txHash: withdrawal.hash },
+      { txHash: withdrawal.initializeHash },
       getChainIdByNetwork(Network.MATIC)
     )
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,7 +37,9 @@
     "status": "Status",
     "datetime": "Date time",
     "to": "Sent to",
-    "tx": "Tx Hash"
+    "tx": "Tx Hash",
+    "initialize_tx": "Tx Hash (Initialize withdrawal)",
+    "finalize_tx": "Tx Hash (Complete withdrawal)"
   },
   "see_all_transaction_modal": {
     "title_ethereum": "Ethereum Transactions",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,7 +36,8 @@
     "type": "Type",
     "status": "Status",
     "datetime": "Date time",
-    "to": "Sent to"
+    "to": "Sent to",
+    "tx": "Tx Hash"
   },
   "see_all_transaction_modal": {
     "title_ethereum": "Ethereum Transactions",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -37,7 +37,9 @@
     "status": "Estado",
     "datetime": "Operacion realizada en",
     "to": "Enviado a",
-    "tx": "Hash de la Transacción"
+    "tx": "Hash de la Transacción",
+    "initialize_tx": "Hash de la Transacción (Inicio del retiro)",
+    "finalize_tx": "Hash de la Transacción (Completado del retiro)"
   },
   "see_all_transaction_modal": {
     "title_ethereum": "Transacciones en Ethereum",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -36,7 +36,8 @@
     "type": "Tipo",
     "status": "Estado",
     "datetime": "Operacion realizada en",
-    "to": "Enviado a"
+    "to": "Enviado a",
+    "tx": "Hash de la Transacción"
   },
   "see_all_transaction_modal": {
     "title_ethereum": "Transacciones en Ethereum",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -36,7 +36,9 @@
     "status": "状态",
     "datetime": "约会时间",
     "to": "发送",
-    "tx": "交易哈希"
+    "tx": "交易哈希",
+    "initialize_tx": "交易哈希（初始取款）",
+    "finalize_tx": "交易哈希（完全取款）"
   },
   "see_all_transaction_modal": {
     "title_ethereum": "Ethereum 交易",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -35,7 +35,8 @@
     "type": "类型",
     "status": "状态",
     "datetime": "约会时间",
-    "to": "发送"
+    "to": "发送",
+    "tx": "交易哈希"
   },
   "see_all_transaction_modal": {
     "title_ethereum": "Ethereum 交易",

--- a/src/modules/mana/actions.ts
+++ b/src/modules/mana/actions.ts
@@ -221,6 +221,14 @@ export const setWithdrawalStatus = (txHash: string, status: WithdrawalStatus) =>
   action(SET_WITHDRAWAL_STATUS, { txHash, status })
 export type SetWithdrawalStatusAction = ReturnType<typeof setWithdrawalStatus>
 
+// Set Withdrawal Finalize Hash
+export const SET_WITHDRAWAL_FINALIZE_HASH = 'Set Withdrawal Finalize Hash'
+export const setWithdrawalFinalizeHash = (
+  withdrawal: Withdrawal,
+  finalizeHash: string
+) => action(SET_WITHDRAWAL_FINALIZE_HASH, { withdrawal, finalizeHash })
+export type SetWithdrawalFinalizeHashAction = ReturnType<typeof setWithdrawalFinalizeHash>
+
 // Finish Withdrawal
 export const FINISH_WITHDRAWAL_REQUEST = '[Request] Finish Withdrawal'
 export const FINISH_WITHDRAWAL_SUCCESS = '[Success] Finish Withdrawal'

--- a/src/modules/mana/reducer.ts
+++ b/src/modules/mana/reducer.ts
@@ -44,6 +44,7 @@ import {
   INITIATE_WITHDRAWAL_REQUEST,
   INITIATE_WITHDRAWAL_SUCCESS,
   SetWithdrawalStatusAction,
+  SetWithdrawalFinalizeHashAction,
   SET_WITHDRAWAL_STATUS,
   WatchWithdrawalStatusRequestAction,
   WatchWithdrawalStatusFailureAction,
@@ -67,6 +68,7 @@ import {
   FinishWithdrawalSuccessAction,
   SetPurchaseAction,
   SET_PURCHASE,
+  SET_WITHDRAWAL_FINALIZE_HASH,
 } from './actions'
 import { Deposit, Withdrawal, WithdrawalStatus, Purchase } from './types'
 
@@ -121,6 +123,7 @@ type ManaReducerAction =
   | WatchWithdrawalStatusSuccessAction
   | WatchWithdrawalStatusFailureAction
   | SetWithdrawalStatusAction
+  | SetWithdrawalFinalizeHashAction
   | FinishWithdrawalSuccessAction
   | FinishWithdrawalRequestAction
   | FinishWithdrawalFailureAction
@@ -293,6 +296,27 @@ export function manaReducer(
             },
           }
         : state
+    }
+
+    case SET_WITHDRAWAL_FINALIZE_HASH: {
+      const { withdrawal: providedWithdrawal, finalizeHash } = action.payload
+      const { withdrawals } = state.data
+
+      const updatedWithdrawals = withdrawals.map((withdrawal) => {
+        if (withdrawal.hash === providedWithdrawal.hash) {
+          return { ...withdrawal, finalizeHash: finalizeHash }
+        }
+
+        return withdrawal
+      })
+
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          withdrawals: updatedWithdrawals,
+        },
+      }
     }
 
     case FINISH_WITHDRAWAL_SUCCESS: {

--- a/src/modules/mana/reducer.ts
+++ b/src/modules/mana/reducer.ts
@@ -339,7 +339,7 @@ export function manaReducer(
               ...state.data,
               withdrawals: [
                 ...state.data.withdrawals.filter(
-                  (_withdraw) => _withdraw.initializeHash !== withdrawal.hash
+                  (_withdraw) => _withdraw.initializeHash !== withdrawal.initializeHash
                 ),
                 {
                   ...withdrawal,

--- a/src/modules/mana/reducer.ts
+++ b/src/modules/mana/reducer.ts
@@ -238,7 +238,8 @@ export function manaReducer(
           ...state.data,
           withdrawals: [
             ...state.data.withdrawals.filter(
-              (_withdraw) => _withdraw.hash !== withdrawal.hash
+              (_withdraw) =>
+                _withdraw.initializeHash !== withdrawal.initializeHash
             ), // remove it if it was already added
             withdrawal,
           ],
@@ -275,7 +276,7 @@ export function manaReducer(
     case SET_WITHDRAWAL_STATUS: {
       const { txHash, status } = action.payload
       const withdrawal = state.data.withdrawals.find(
-        (withdrawal) => withdrawal.hash === txHash
+        (withdrawal) => withdrawal.initializeHash === txHash
       )
       return withdrawal
         ? {
@@ -286,7 +287,8 @@ export function manaReducer(
               withdrawals: [
                 // replace old tx with new one
                 ...state.data.withdrawals.filter(
-                  (_withdrawal) => withdrawal.hash !== _withdrawal.hash
+                  (_withdrawal) =>
+                    withdrawal.initializeHash !== _withdrawal.initializeHash
                 ),
                 {
                   ...withdrawal,
@@ -303,7 +305,7 @@ export function manaReducer(
       const { withdrawals } = state.data
 
       const updatedWithdrawals = withdrawals.map((withdrawal) => {
-        if (withdrawal.hash === providedWithdrawal.hash) {
+        if (withdrawal.initializeHash === providedWithdrawal.initializeHash) {
           return { ...withdrawal, finalizeHash: finalizeHash }
         }
 
@@ -337,7 +339,7 @@ export function manaReducer(
               ...state.data,
               withdrawals: [
                 ...state.data.withdrawals.filter(
-                  (_withdraw) => _withdraw.hash !== withdrawal.hash
+                  (_withdraw) => _withdraw.initializeHash !== withdrawal.hash
                 ),
                 {
                   ...withdrawal,

--- a/src/modules/mana/selectors.ts
+++ b/src/modules/mana/selectors.ts
@@ -129,7 +129,7 @@ export const getTransactionByNetwork = createSelector<
       const { network } = getChainConfiguration(tx.chainId)
       const deposit = deposits.find((deposit) => tx.hash === deposit.hash)
       const withdrawal = withdrawals.find(
-        (withdrawal) => tx.hash === withdrawal.hash
+        (withdrawal) => tx.hash === withdrawal.initializeHash
       )
       if (deposit) {
         const accountTransaction: AccountTransaction<Deposit> = {

--- a/src/modules/mana/types.ts
+++ b/src/modules/mana/types.ts
@@ -67,7 +67,7 @@ export enum WithdrawalStatus {
 }
 
 export type Withdrawal = {
-  hash: string
+  initializeHash: string
   finalizeHash: string | null
   status: WithdrawalStatus
   from: string

--- a/src/modules/mana/types.ts
+++ b/src/modules/mana/types.ts
@@ -68,6 +68,7 @@ export enum WithdrawalStatus {
 
 export type Withdrawal = {
   hash: string
+  finalizeHash: string | null
   status: WithdrawalStatus
   from: string
   amount: number

--- a/src/modules/migrations/index.ts
+++ b/src/modules/migrations/index.ts
@@ -1,0 +1,5 @@
+import v2 from './v2'
+
+export default {
+  '2': v2,
+}

--- a/src/modules/migrations/index.ts
+++ b/src/modules/migrations/index.ts
@@ -1,5 +1,7 @@
 import v2 from './v2'
 
-export default {
+const migrations = {
   '2': v2,
 }
+
+export default migrations

--- a/src/modules/migrations/v2.spec.ts
+++ b/src/modules/migrations/v2.spec.ts
@@ -1,0 +1,46 @@
+import { WithdrawalStatus } from '../mana/types'
+import v2 from './v2'
+
+describe('migrations - v2', () => {
+  it('should migrate from previous version', () => {
+    const makeOldWithdrawal = () => ({
+      amount: 1,
+      hash: 'hash',
+      from: 'from',
+      status: WithdrawalStatus.PENDING,
+      timestamp: 1,
+    })
+
+    const oldState: any = {
+      mana: {
+        data: {
+          withdrawals: [makeOldWithdrawal()],
+        },
+      },
+      transaction: {
+        data: [
+          { payload: undefined },
+          { payload: { foo: 'bar' } },
+          { payload: { withdrawal: makeOldWithdrawal() } },
+        ],
+      },
+    }
+
+    const state = v2(oldState)
+
+    const withdrawal = state.mana.data.withdrawals[0]
+
+    expect(withdrawal.finalizeHash).toBeNull()
+    expect(withdrawal.initializeHash).toBe('hash')
+
+    const transactionPayload0 = state.transaction.data[0].payload
+    const transactionPayload1 = state.transaction.data[1].payload
+    const transactionPayload2 = state.transaction.data[2].payload
+
+    expect(transactionPayload0).toBeUndefined()
+    expect(transactionPayload1.foo).toBe('bar')
+
+    expect(transactionPayload2.withdrawal.finalizeHash).toBeNull()
+    expect(transactionPayload2.withdrawal.initializeHash).toBe('hash')
+  })
+})

--- a/src/modules/migrations/v2.ts
+++ b/src/modules/migrations/v2.ts
@@ -1,0 +1,43 @@
+import { Withdrawal } from '../mana/types'
+import { RootState } from '../reducer'
+
+export default (state: RootState) => {
+  const oldWithdrawals = state.mana.data.withdrawals
+  const oldTransactions = state.transaction.data
+  const updatedWithdrawals = oldWithdrawals.map(mapOldWithdrawal)
+  const updatedTransactions = oldTransactions.map(mapOldTransactions)
+
+  return {
+    ...state,
+    mana: {
+      ...state.mana,
+      data: {
+        ...state.mana.data,
+        withdrawals: updatedWithdrawals,
+      },
+    },
+    transaction: {
+      ...state.transaction,
+      data: updatedTransactions,
+    },
+  }
+}
+
+const mapOldWithdrawal = (withdrawal: any): Withdrawal => ({
+  amount: withdrawal.amount,
+  from: withdrawal.from,
+  status: withdrawal.status,
+  timestamp: withdrawal.timestamp,
+  finalizeHash: null,
+  initializeHash: (withdrawal as any).hash,
+})
+
+const mapOldTransactions = (transaction: any) => ({
+  ...transaction,
+  payload: transaction.payload?.withdrawal
+    ? {
+        ...transaction.payload,
+        withdrawal: mapOldWithdrawal(transaction.payload.withdrawal),
+      }
+    : transaction.payload,
+})

--- a/src/modules/migrations/v2.ts
+++ b/src/modules/migrations/v2.ts
@@ -1,7 +1,7 @@
 import { Withdrawal } from '../mana/types'
 import { RootState } from '../reducer'
 
-export default (state: RootState) => {
+const v2 = (state: RootState) => {
   const oldWithdrawals = state.mana.data.withdrawals
   const oldTransactions = state.transaction.data
   const updatedWithdrawals = oldWithdrawals.map(mapOldWithdrawal)
@@ -41,3 +41,5 @@ const mapOldTransactions = (transaction: any) => ({
       }
     : transaction.payload,
 })
+
+export default v2

--- a/src/modules/store.ts
+++ b/src/modules/store.ts
@@ -24,8 +24,7 @@ const rootReducer = storageReducerWrapper(createRootReducer(history))
 const sagasMiddleware = createSagasMiddleware()
 const loggerMiddleware = createLogger({
   collapsed: () => true,
-  predicate: (_: any, action) =>
-    isDevelopment || action.type.includes('Failure'),
+  predicate: (_: any, action) => isDevelopment || action.type.includes('Failure'),
 })
 
 const transactionMiddleware = createTransactionMiddleware()

--- a/src/modules/store.ts
+++ b/src/modules/store.ts
@@ -6,8 +6,7 @@ import { createStorageMiddleware } from 'decentraland-dapps/dist/modules/storage
 import { storageReducerWrapper } from 'decentraland-dapps/dist/modules/storage/reducer'
 import { createTransactionMiddleware } from 'decentraland-dapps/dist/modules/transaction/middleware'
 import { createAnalyticsMiddleware } from 'decentraland-dapps/dist/modules/analytics/middleware'
-
-import { createRootReducer } from './reducer'
+import { createRootReducer, RootState } from './reducer'
 import { rootSaga } from './sagas'
 import {
   SET_DEPOSIT_STATUS,
@@ -43,7 +42,22 @@ const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
     WATCH_WITHDRAWAL_STATUS_SUCCESS,
     SET_PURCHASE,
   ],
-  migrations: {},
+  migrations: {
+    '2': (state: RootState) => {
+      const withdrawals = state.mana.data.withdrawals
+
+      state.mana.data.withdrawals = withdrawals.map((w) => {
+        //@ts-ignore
+        w.initializeHash = w.hash
+        w.finalizeHash = null
+        //@ts-ignore
+        delete w.hash
+        return w
+      })
+
+      return state
+    },
+  },
 })
 const analyticsMiddleware = createAnalyticsMiddleware(
   process.env.REACT_APP_SEGMENT_API_KEY || ''

--- a/src/modules/store.ts
+++ b/src/modules/store.ts
@@ -6,7 +6,7 @@ import { createStorageMiddleware } from 'decentraland-dapps/dist/modules/storage
 import { storageReducerWrapper } from 'decentraland-dapps/dist/modules/storage/reducer'
 import { createTransactionMiddleware } from 'decentraland-dapps/dist/modules/transaction/middleware'
 import { createAnalyticsMiddleware } from 'decentraland-dapps/dist/modules/analytics/middleware'
-import { createRootReducer, RootState } from './reducer'
+import { createRootReducer } from './reducer'
 import { rootSaga } from './sagas'
 import {
   SET_DEPOSIT_STATUS,
@@ -16,7 +16,7 @@ import {
   WATCH_WITHDRAWAL_STATUS_SUCCESS,
 } from './mana/actions'
 import { isDevelopment } from '../lib/environment'
-import { Withdrawal } from './mana/types'
+import migrations from './migrations'
 
 export const history = require('history').createBrowserHistory()
 const rootReducer = storageReducerWrapper(createRootReducer(history))
@@ -43,48 +43,7 @@ const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
     WATCH_WITHDRAWAL_STATUS_SUCCESS,
     SET_PURCHASE,
   ],
-  migrations: {
-    '2': (state: RootState) => {
-      const oldWithdrawals = state.mana.data.withdrawals
-      const oldTransactions = state.transaction.data
-
-      const mapOldWithdrawal = (withdrawal: any): Withdrawal => ({
-        amount: withdrawal.amount,
-        from: withdrawal.from,
-        status: withdrawal.status,
-        timestamp: withdrawal.timestamp,
-        finalizeHash: null,
-        initializeHash: (withdrawal as any).hash,
-      })
-
-      const updatedWithdrawals = oldWithdrawals.map(mapOldWithdrawal)
-      const updatedTransactions = oldTransactions.map((transaction) => ({
-        ...transaction,
-        payload:
-          transaction.payload && transaction.payload.withdrawal
-            ? {
-                ...transaction.payload,
-                withdrawal: mapOldWithdrawal(transaction.payload.withdrawal),
-              }
-            : transaction.payload,
-      }))
-
-      return {
-        ...state,
-        mana: {
-          ...state.mana,
-          data: {
-            ...state.mana.data,
-            withdrawals: updatedWithdrawals,
-          },
-        },
-        transaction: {
-          ...state.transaction,
-          data: updatedTransactions,
-        },
-      }
-    },
-  },
+  migrations,
 })
 const analyticsMiddleware = createAnalyticsMiddleware(
   process.env.REACT_APP_SEGMENT_API_KEY || ''


### PR DESCRIPTION
Closes #124 

- Added link to `Etherscan` on Deposit transactions
- Added link to `Etherscan` or `Polygonscan` on Send transactions depending on what was sent
- Added both `Etherscan` and `Polygonscan` links to explorer on Withdrawal transactions
- Clicking on Withdrawal initialized status check in the `WithdrawalStatusModal` takes you to the trx on `Polygonscan`
- Clicking on Complete withdrawal status check (After submitting the complete withdrawal transaction) in the `WithdrawalStatusModal` takes you to the trx on `Etherscan`.
- Added a storage migration due to the changes on the `Withdrawal` type

![image](https://user-images.githubusercontent.com/24811313/132367344-09083c01-8c5a-42f3-ab26-1e99f02363ad.png)
![Screen Shot 2021-09-07 at 12 09 02](https://user-images.githubusercontent.com/24811313/132368537-5893f800-56a9-47ee-b13b-b95a3a4f2c83.png)
![image](https://user-images.githubusercontent.com/24811313/132368626-dae2fb56-af65-43e4-a9dd-e4884f1e90df.png)

