### PR TITLE
feat: Calculate the cost of withdrawing MANA to Ethereum

### DIFF
--- a/src/components/Modals/ConvertManaModal/ConvertManaModal.css
+++ b/src/components/Modals/ConvertManaModal/ConvertManaModal.css
@@ -95,7 +95,7 @@
   line-height: 26px;
 }
 
-.ConvertManaModal button.ui.primary {
+.ConvertManaModal button.ui.primary.start-transaction-button {
   margin-top: 20px;
   width: 100%;
 }

--- a/src/components/Modals/ConvertManaModal/ConvertManaModal.tsx
+++ b/src/components/Modals/ConvertManaModal/ConvertManaModal.tsx
@@ -92,6 +92,7 @@ const ConvertManaModal: React.FC<Props> = ({
         const cost = await getEstimatedExitTransactionCost()
         if (!cancel) setTxEstimatedCost(cost)
       } catch (error) {
+        setHasAcceptedWithdrawalCost(true)
         setTxEstimatedCost(null)
       }
     }
@@ -121,8 +122,6 @@ const ConvertManaModal: React.FC<Props> = ({
                 cost: <b>{txEstimatedCost.toFixed(2)}</b>,
               }}
             />
-          ) : txEstimatedCost === null ? (
-            t('convert_mana_modal.withdrawal_cost_error')
           ) : (
             <Loader size="tiny" />
           )}

--- a/src/lib/api/gasPrice.ts
+++ b/src/lib/api/gasPrice.ts
@@ -1,0 +1,31 @@
+const GAS_PRICE_API_URL = 'https://api.gasprice.io/v1'
+
+interface GasPriceEstimatesResponse {
+  error: null
+  result: {
+    instant: {
+      feeCap: number
+      maxPriorityFee: number
+    }
+    fast: {
+      feeCap: number
+      maxPriorityFee: number
+    }
+    eco: {
+      feeCap: number
+      maxPriorityFee: number
+    }
+    baseFee: number
+    ethPrice: number
+  }
+}
+
+class GasPriceAPI {
+  async fetchGasPrice(): Promise<GasPriceEstimatesResponse> {
+    const resp = await fetch(`${GAS_PRICE_API_URL}/estimates`)
+    const json = await resp.json()
+    return json
+  }
+}
+
+export const gasPriceAPI = new GasPriceAPI()

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,12 +81,12 @@
     }
   },
   "import_withdrawal_modal": {
-    "title":"Import Withdrawal",
+    "title": "Import Withdrawal",
     "description": "Withdrawals are a 2-step process. You initialize a withdrawal with a Polygon transaction that burns your Polygon MANA, and after some minutes you are able to unlock your MANA tokens on Ethereum. We store the information from the first transaction on your device, and it's necessary to finish your withdrawal. If for some reason this information is lost (ie. you erase your browser's storage) or if you are finishing your withdrawal from a new device, you can use this screen to recover your withdrawal information by entering the hash of the withdrawal initialization transaction (in Polygon). You can see all your latest transaction on {link}",
     "polygonscan": "Polygonscan",
     "tx_label": "Tx Hash",
     "import_withdrawal": "Import",
-    "errors":{
+    "errors": {
       "invalid_hash": "Invalid Hash",
       "duplicate": "This Withdrawal already exists on your list",
       "not_found": "Not found",
@@ -113,7 +113,11 @@
     "title_matic": "Convert to Ethereum MANA",
     "subtitle_matic": "Withdraw MANA from Polygon into Ethereum",
     "label_approvement": "MANA Approved",
-    "no_balance": "You don't have enough balance"
+    "no_balance": "You don't have enough balance",
+    "withdrawal_cost": "This operation consists of two steps. The first step won't have any cost. The second one will cost a approximately ${cost} of gas fees on Ethereum",
+    "withdrawal_cost_error": "There was an error trying to calculate the transaction cost",
+    "withdrawal_cost_accept": "Proceed",
+    "withdrawal_cost_cancel": "Cancel"
   },
   "withdrawal_status_modal": {
     "title": "Convert to Mana",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -115,7 +115,6 @@
     "label_approvement": "MANA Approved",
     "no_balance": "You don't have enough balance",
     "withdrawal_cost": "This operation consists of two steps. The first step won't have any cost. The second one will cost a approximately ${cost} of gas fees on Ethereum",
-    "withdrawal_cost_error": "There was an error trying to calculate the transaction cost",
     "withdrawal_cost_accept": "Proceed",
     "withdrawal_cost_cancel": "Cancel"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -115,7 +115,6 @@
     "label_approvement": "MANA Approved",
     "no_balance": "You don't have enough balance",
     "withdrawal_cost": "This operation consists of two steps. The first step won't have any cost. The second one will cost approximately {cost} of gas fees on Ethereum.",
-    "withdrawal_cost_error": "There was an error trying to calculate the transaction cost",
     "withdrawal_cost_accept": "Proceed",
     "withdrawal_cost_cancel": "Cancel"
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -80,12 +80,12 @@
     }
   },
   "import_withdrawal_modal": {
-    "title":"Importar Retiro",
+    "title": "Importar Retiro",
     "description": "Los retiros son un proceso de 2 pasos. Inicializa un retiro con una transacción de Polygon que quema su Polygon MANA, y después de unos minutos puede desbloquear sus tokens MANA en Ethereum. Almacenamos la información de la primera transacción en su dispositivo, y es necesario para finalizar su retiro. Si por alguna razón esta información se pierde (es decir, borra el almacenamiento de su navegador) o si está terminando su retiro de un nuevo dispositivo, puede usar esta pantalla para recuperar su información de retiro ingresando el hash de la transacción de inicialización de retiro (en Polygon). Puedes ver todas tus últimas transacciones en {link}",
     "polygonscan": "Polygonscan",
     "tx_label": "Hash de la Transacción",
     "import_withdrawal": "Importar",
-    "errors":{
+    "errors": {
       "invalid_hash": "Hash invalido",
       "duplicate": "Este retiro ya existe en su listado",
       "not_found": "No se encuentra",
@@ -112,7 +112,11 @@
     "title_matic": "Convertir a MANA en Ethereum",
     "subtitle_matic": "Retira MANA de Polygon a Ethereum",
     "label_approvement": "MANA Aprobado",
-    "no_balance": "No tiene suficientes fondos"
+    "no_balance": "No tiene suficientes fondos",
+    "withdrawal_cost": "Esta operación consta de dos pasos. El primer paso no tendrá ningún costo. El segundo costará aproximadamente ${cost} de gas en Ethereum",
+    "withdrawal_cost_error": "Hubo un error al intentar calcular el costo de la transacción",
+    "withdrawal_cost_accept": "Continuar",
+    "withdrawal_cost_cancel": "Cancelar"
   },
   "withdrawal_status_modal": {
     "title": "Convertir a Mana",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -114,7 +114,6 @@
     "label_approvement": "MANA Aprobado",
     "no_balance": "No tiene suficientes fondos",
     "withdrawal_cost": "Esta operación consta de dos pasos. El primer paso no tendrá ningún costo. El segundo costará aproximadamente ${cost} de gas en Ethereum",
-    "withdrawal_cost_error": "Hubo un error al intentar calcular el costo de la transacción",
     "withdrawal_cost_accept": "Continuar",
     "withdrawal_cost_cancel": "Cancelar"
   },

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -113,7 +113,6 @@
     "label_approvement": "获MANA批准",
     "no_balance": "您的余额不足",
     "withdrawal_cost": "该操作包括两个步骤。第一步不会有任何费用。第二个将在以太坊上花费大约 ${cost} 的汽油费",
-    "withdrawal_cost_error": "尝试计算交易成本时出错",
     "withdrawal_cost_accept": "继续",
     "withdrawal_cost_cancel": "取消"
   },

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -111,7 +111,11 @@
     "title_matic": "转换为MANA",
     "subtitle_matic": "将MANA从Polygon撤至Ethereum",
     "label_approvement": "获MANA批准",
-    "no_balance": "您的余额不足"
+    "no_balance": "您的余额不足",
+    "withdrawal_cost": "该操作包括两个步骤。第一步不会有任何费用。第二个将在以太坊上花费大约 ${cost} 的汽油费",
+    "withdrawal_cost_error": "尝试计算交易成本时出错",
+    "withdrawal_cost_accept": "继续",
+    "withdrawal_cost_cancel": "取消"
   },
   "withdrawal_status_modal": {
     "title": "转化为法力",

--- a/src/modules/mana/utils.ts
+++ b/src/modules/mana/utils.ts
@@ -279,7 +279,7 @@ export function* getStoreWithdrawalByHash(hash: string) {
   return withdrawals.find((w) => w.initializeHash === hash)
 }
 
-const EXIT_CONTRACT_GAS_CONSUMPTION = 238325 // gas in wei
+const EXIT_CONTRACT_GAS_CONSUMPTION = 260670 // gas in wei
 
 export async function getEstimatedExitTransactionCost() {
   const {


### PR DESCRIPTION
Closes #172 

## Description

Introduces a new util method to calculate the cost of the withdrawal operation to Ethereum. 
Tech details:
- Uses the Gas Price API to get the current gas price (and uses the `fast` one). The `/estimates` endpoint also returns the current ETH price in USD, so it wasn't neccesarry to fetch it from Coingecko.
- The amount of gas consumed by the contract was gathered from a [withdrawal operation made in Goerli](https://goerli.etherscan.io/tx/0xc23b6ec66cd61f39245bd1b4fe0e5359526699f5159d7861a6c2bf19855544e8)

![image](https://user-images.githubusercontent.com/8763687/150850652-1c114c08-41a1-4075-b04a-c7a297c2db5a.png)
 

![image](https://user-images.githubusercontent.com/8763687/150850197-adafbeb0-2d15-4e54-88c0-69f75f5c6c46.png)
