### PR TITLE
chore: upgrade @transak/transak-sdk from v1.0.28 to v1.0.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@testing-library/jest-dom": "^5.11.8",
         "@testing-library/react": "^11.2.2",
         "@testing-library/user-event": "^12.6.0",
-        "@transak/transak-sdk": "^1.0.28",
+        "@transak/transak-sdk": "^1.0.31",
         "@typechain/ethers-v5": "^10.0.0",
         "@types/jest": "^26.0.19",
         "@types/node": "^12.19.11",
@@ -6337,9 +6337,10 @@
       }
     },
     "node_modules/@transak/transak-sdk": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@transak/transak-sdk/-/transak-sdk-1.0.30.tgz",
-      "integrity": "sha512-8P1wfMwW/+DpD0aHMh0/8C4sa5rOamd0yeVUoGZRwEsmSUub+WBVB9WhiI9c/H4IOnZb470CJSsGu8PS/N927g==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@transak/transak-sdk/-/transak-sdk-1.0.31.tgz",
+      "integrity": "sha512-mja3qlFW71cTOXGSIrIPv4QPkcQ6ff3nXtJk0b5EzmqiU7CZWWstYf5cc5fJcmVO4/tWI0pP4S2Ex1iPUAcxwQ==",
+      "license": "ISC",
       "dependencies": {
         "events": "^3.1.0",
         "query-string": "^6.12.1",
@@ -34153,9 +34154,9 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
     "@transak/transak-sdk": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@transak/transak-sdk/-/transak-sdk-1.0.30.tgz",
-      "integrity": "sha512-8P1wfMwW/+DpD0aHMh0/8C4sa5rOamd0yeVUoGZRwEsmSUub+WBVB9WhiI9c/H4IOnZb470CJSsGu8PS/N927g==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@transak/transak-sdk/-/transak-sdk-1.0.31.tgz",
+      "integrity": "sha512-mja3qlFW71cTOXGSIrIPv4QPkcQ6ff3nXtJk0b5EzmqiU7CZWWstYf5cc5fJcmVO4/tWI0pP4S2Ex1iPUAcxwQ==",
       "requires": {
         "events": "^3.1.0",
         "query-string": "^6.12.1",
@@ -37806,7 +37807,6 @@
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
         "@dcl/crypto": "^3.0.0",
-        "@dcl/schemas": "^4.6.0",
         "@types/flat": "0.0.28",
         "@types/uuid": "^3.4.3",
         "axios": "^0.21.1",
@@ -37847,8 +37847,6 @@
         "deep-equal": "^2.0.5",
         "ethereum-blockies": "^0.1.1",
         "parallax-js": "^3.1.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
         "react-responsive": "^9.0.0-beta.3",
         "react-tile-map": "^0.3.2",
         "semantic-ui-css": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.6.0",
-    "@transak/transak-sdk": "^1.0.28",
+    "@transak/transak-sdk": "^1.0.31",
     "@typechain/ethers-v5": "^10.0.0",
     "@types/jest": "^26.0.19",
     "@types/node": "^12.19.11",


### PR DESCRIPTION
This PR upgraded the @transak/transak-sdk library version from v1.0.20 to v1.0.31.

Closes: #146 