### PR TITLE
fix: Display MANA with decimals in the AccountCard

### DIFF
--- a/src/components/HomePage/AccountCard/AccountCardHeader/AccountCardHeader.tsx
+++ b/src/components/HomePage/AccountCard/AccountCardHeader/AccountCardHeader.tsx
@@ -79,7 +79,7 @@ const AccountCardHeader = ({
             <div
               className={network === Network.MATIC ? 'matic-logo' : 'mana-logo'}
             />
-            {(amount | 0).toLocaleString()}
+            {(amount ? Number(amount.toFixed(2)) : 0).toLocaleString()}
           </div>
         </div>
         <div className="actions">


### PR DESCRIPTION
This PR fixes how the AccountCard displays MANA.

Closes: #215 