### PR TITLE
fix: Show authorization modal for magic users

### DIFF
--- a/src/components/Modals/ConvertManaModal/ConvertManaModal.tsx
+++ b/src/components/Modals/ConvertManaModal/ConvertManaModal.tsx
@@ -53,6 +53,7 @@ const ConvertManaModal: React.FC<Props> = ({
         onClearManaError()
 
         onAuthorizedAction({
+          manual: true,
           authorizationType: AuthorizationType.ALLOWANCE,
           authorizedAddress: ERC20_PREDICATE_CONTRACT_ADDRESS,
           authorizedContractLabel: 'ERC20 Predicate',


### PR DESCRIPTION
This PR adds the manual mode for the Ethereum contract authorization.